### PR TITLE
Add OpenAI-compatible support

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,11 +268,12 @@ Use a specific Claude model:
 
 ## Cloud Providers
 
-You can authenticate with Claude using any of these three methods:
+You can authenticate with Claude using any of these methods:
 
 1. Direct Anthropic API (default)
 2. Amazon Bedrock with OIDC authentication
 3. Google Vertex AI with OIDC authentication
+4. OpenAI-compatible providers (OpenAI, OpenRouter)
 
 For detailed setup instructions for AWS Bedrock and Google Vertex AI, see the [official documentation](https://docs.anthropic.com/en/docs/claude-code/github-actions#using-with-aws-bedrock-%26-google-vertex-ai).
 
@@ -305,6 +306,14 @@ Use provider-specific model names based on your chosen provider:
   with:
     model: "claude-3-7-sonnet@20250219"
     use_vertex: "true"
+    # ... other inputs
+
+# For OpenAI-compatible providers (OpenAI or OpenRouter)
+- uses: anthropics/claude-code-action@beta
+  with:
+    openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+    # openai_base_url: "https://openrouter.ai/api/v1"   # Optional for OpenRouter
+    model: "codex-mini-latest"
     # ... other inputs
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,13 @@ inputs:
     required: false
     default: ""
 
+  openai_api_key:
+    description: "API key for OpenAI-compatible providers (OpenAI, OpenRouter, etc.)"
+    required: false
+  openai_base_url:
+    description: "Base URL for OpenAI-compatible API (optional)"
+    required: false
+
   # Auth configuration
   anthropic_api_key:
     description: "Anthropic API key (required for direct API, not needed for Bedrock/Vertex)"
@@ -116,6 +123,8 @@ runs:
 
         # Provider configuration
         ANTHROPIC_BASE_URL: ${{ env.ANTHROPIC_BASE_URL }}
+        OPENAI_API_KEY: ${{ inputs.openai_api_key }}
+        OPENAI_BASE_URL: ${{ inputs.openai_base_url }}
 
         # AWS configuration
         AWS_REGION: ${{ env.AWS_REGION }}

--- a/examples/openai.yml
+++ b/examples/openai.yml
@@ -1,0 +1,19 @@
+name: OpenAI Codex Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  codex-response:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: anthropics/claude-code-action@beta
+        with:
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          # openai_base_url: "https://openrouter.ai/api/v1"  # Uncomment for OpenRouter
+          model: "codex-mini-latest"

--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -396,7 +396,7 @@ Images have been downloaded from GitHub comments and saved to disk. Their file p
     ? formatBody(contextData.body, imageUrlMap)
     : "No description provided";
 
-  let promptContent = `You are Claude, an AI assistant designed to help with GitHub issues and pull requests. Think carefully as you analyze the context and respond appropriately. Here's the context for your current task:
+  let promptContent = `You are an AI assistant (Claude or an OpenAI-compatible model). When using smaller models such as \`codex-mini-latest\`, keep responses concise and rely heavily on the provided context. Here's the context for your current task:
 
 <formatted_context>
 ${formattedContext}


### PR DESCRIPTION
## Summary
- support OpenAI compatible models via new inputs `openai_api_key` and `openai_base_url`
- tweak prompt wording for codex-mini-latest support
- document OpenAI workflow usage and add example

## Testing
- `bun test` *(fails: Cannot find module '@actions/core')*